### PR TITLE
Add WebAssembly portability to core emulator

### DIFF
--- a/Sources/Chip8Emulator/BeepPlayer.swift
+++ b/Sources/Chip8Emulator/BeepPlayer.swift
@@ -1,10 +1,11 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Ryan Grey on 24/02/2021.
 //
 
+#if canImport(AVFoundation)
 import Foundation
 import AVFoundation
 
@@ -31,3 +32,4 @@ public struct BeepPlayer {
         }
     }
 }
+#endif

--- a/Sources/Chip8Emulator/Bundle_Emulator.swift
+++ b/Sources/Chip8Emulator/Bundle_Emulator.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit) || canImport(UIKit)
 import class Foundation.Bundle
 
 extension Foundation.Bundle {
@@ -5,3 +6,4 @@ extension Foundation.Bundle {
         return Bundle.module
     }
 }
+#endif

--- a/Sources/Chip8Emulator/Chip8.swift
+++ b/Sources/Chip8Emulator/Chip8.swift
@@ -43,10 +43,13 @@ class Chip8: Chip8KeyHandler {
     }
 
     func handleKeyDown(key: Chip8InputCode) {
-        state.downKeys.add(Byte(key.rawValue))
+        let byte = Byte(key.rawValue)
+        if !state.downKeys.contains(byte) {
+            state.downKeys.append(byte)
+        }
     }
 
     func handleKeyUp(key: Chip8InputCode) {
-        state.downKeys.remove(Byte(key.rawValue))
+        state.downKeys.removeAll(where: { $0 == Byte(key.rawValue) })
     }
 }

--- a/Sources/Chip8Emulator/Chip8Engine.swift
+++ b/Sources/Chip8Emulator/Chip8Engine.swift
@@ -1,6 +1,6 @@
 //
 //  Chip8Engine.swift
-//  
+//
 //
 //  Created by Ryan Grey on 26/02/2021.
 //
@@ -8,10 +8,14 @@
 import Foundation
 
 public class Chip8Engine: Chip8KeyHandler {
+    #if canImport(ObjectiveC)
     private var timer: Timer?
+    #endif
     private let cpuHz: TimeInterval = 1/600
     private var chip8: Chip8?
+    #if canImport(AVFoundation)
     private let beepPlayer = BeepPlayer()
+    #endif
     public var delegate: Chip8EngineDelegate?
 
     public init() {
@@ -19,7 +23,7 @@ public class Chip8Engine: Chip8KeyHandler {
 
     public func start(with rom: [Byte]) {
         stop()
-        
+
         var chipState = ChipState()
         chipState.ram = rom
 
@@ -27,18 +31,19 @@ public class Chip8Engine: Chip8KeyHandler {
             state: chipState,
             cpuHz: cpuHz
         )
-        
+
         resume()
     }
-    
-    private var isRunning: Bool {
-        return timer != nil
-    }
-    
+
     private var isLoaded: Bool {
         return chip8 != nil
     }
-    
+
+    #if canImport(ObjectiveC)
+    private var isRunning: Bool {
+        return timer != nil
+    }
+
     public func resume() {
         guard !isRunning && isLoaded else { return }
 
@@ -57,8 +62,21 @@ public class Chip8Engine: Chip8KeyHandler {
     }
 
     @objc private func timerFired() {
+        tick()
+    }
+    #else
+    public func resume() {
+        // On non-ObjC platforms (e.g. WASM), the caller drives the loop via tick()
+    }
+
+    public func stop() {
+        // On non-ObjC platforms, the caller manages the loop
+    }
+    #endif
+
+    public func tick() {
         guard let chip8 = chip8 else { return }
-        
+
         chip8.cycle()
         guard let delegate = delegate else { return }
         if chip8.needsRedraw {

--- a/Sources/Chip8Emulator/ChipState.swift
+++ b/Sources/Chip8Emulator/ChipState.swift
@@ -21,7 +21,7 @@ struct ChipState {
         soundTimer: TimeInterval = 0,
         // 12 or 16 sized stack in real Chip-8, but allow this to grow dynamically
         stack: [Word] = [Word](),
-        downKeys: NSMutableOrderedSet = NSMutableOrderedSet(),
+        downKeys: [Byte] = [],
         isAwaitingKey: Bool = false,
         needsRedraw: Bool = false) {
         self.ram = ram
@@ -48,7 +48,7 @@ struct ChipState {
     // stack of currently pressed keys
     // last pressed key at top of stack
     // first pressed key on bottom of stak
-    var downKeys: NSMutableOrderedSet
+    var downKeys: [Byte]
     var isAwaitingKey: Bool
     var needsRedraw: Bool
     

--- a/Sources/Chip8Emulator/OpExecutor.swift
+++ b/Sources/Chip8Emulator/OpExecutor.swift
@@ -221,7 +221,7 @@ struct OpExecutor {
         case (0x0f, let x, 0x00, 0x0a):
             // FX0A, KeyOp, A key press is awaited, and then stored in VX. (Blocking Operation. All instruction halted until next key event)
             // WAITKEY
-            if let key = state.downKeys.lastObject as? Int, state.isAwaitingKey {
+            if let key = state.downKeys.last, state.isAwaitingKey {
                 newState.v[x] = Byte(key)
                 newState.isAwaitingKey = false
                 newState.pc += 2

--- a/Sources/Chip8Emulator/PathFactory.swift
+++ b/Sources/Chip8Emulator/PathFactory.swift
@@ -5,6 +5,7 @@
 //  Created by Ryan Grey on 12/02/2021.
 //
 
+#if canImport(CoreGraphics)
 import Foundation
 import CoreGraphics
 
@@ -59,3 +60,4 @@ extension CGFloat {
         return final
     }
 }
+#endif

--- a/Sources/Chip8Emulator/RomLoader.swift
+++ b/Sources/Chip8Emulator/RomLoader.swift
@@ -16,6 +16,7 @@ import AppKit
 #endif
 
 public struct RomLoader {
+    #if canImport(AppKit) || canImport(UIKit)
     public static func loadRam(from romName: RomName) -> [Byte] {
         guard let romData = NSDataAsset(name: romName.rawValue, bundle: Bundle.emulator)?.data else {
             print("Rom not found: " + romName.rawValue)
@@ -43,8 +44,9 @@ public struct RomLoader {
             return []
         }
     }
+    #endif
 
-    private static func loadRam(from rom: [Byte]) -> [Byte] {
+    public static func loadRam(from rom: [Byte]) -> [Byte] {
         var ram = [Byte](repeating: 0, count: 4096)
 
         let font = Font.bytes

--- a/Tests/Chip8EmulatorTests/OpExecutorTests.swift
+++ b/Tests/Chip8EmulatorTests/OpExecutorTests.swift
@@ -1125,7 +1125,7 @@ class OpExecutorTests: XCTestCase {
         var state = ChipState()
         state.pc = initialPc
         state.v = v
-        state.downKeys.add(triggerKey)
+        state.downKeys.append(Byte(triggerKey))
 
         let newState = try! opExecutor.handle(state: state, op: op)
         let observedPc = newState.pc
@@ -1180,7 +1180,7 @@ class OpExecutorTests: XCTestCase {
         var state = ChipState()
         state.pc = initialPc
         state.v = v
-        state.downKeys.add(triggerKey)
+        state.downKeys.append(Byte(triggerKey))
 
         let newState = try! opExecutor.handle(state: state, op: op)
         let observedPc = newState.pc
@@ -1213,10 +1213,9 @@ class OpExecutorTests: XCTestCase {
     func test_WAITKEY_0x0f_awaits() {
         let x: Byte = 0x02
         let op = Word(nibbles: [0x0f, x, 0x00, 0x0a])
-        let downKeys = NSMutableOrderedSet()
 
         var state = ChipState()
-        state.downKeys = downKeys
+        state.downKeys = []
 
         let newState = try! opExecutor.handle(state: state, op: op)
         let observedAwaiting = newState.isAwaitingKey
@@ -1226,11 +1225,10 @@ class OpExecutorTests: XCTestCase {
     func test_WAITKEY_0x0f_awaits_without_incrementing_pc() {
         let x: Byte = 0x02
         let op = Word(nibbles: [0x0f, x, 0x00, 0x0a])
-        let downKeys = NSMutableOrderedSet()
         let initialPc: Word = 0x88a
 
         var state = ChipState()
-        state.downKeys = downKeys
+        state.downKeys = []
         state.pc = initialPc
 
         let newState = try! opExecutor.handle(state: state, op: op)
@@ -1242,13 +1240,11 @@ class OpExecutorTests: XCTestCase {
     func test_WAITKEY_0x0f_resets_isAwaiting_when_awaited_key_pressed() {
         let x: Byte = 0x02
         let op = Word(nibbles: [0x0f, x, 0x00, 0x0a])
-        let downKeys = NSMutableOrderedSet()
         let awaitedKey: Byte = 1
-        downKeys.add(awaitedKey)
         let initialIsAwaiting = true
 
         var state = ChipState()
-        state.downKeys = downKeys
+        state.downKeys = [awaitedKey]
         state.isAwaitingKey = initialIsAwaiting
 
         let newState = try! opExecutor.handle(state: state, op: op)
@@ -1261,14 +1257,12 @@ class OpExecutorTests: XCTestCase {
         let op = Word(nibbles: [0x0f, x, 0x00, 0x0a])
         var v = createEmptyRegisters()
         v[x] = 1
-        let downKeys = NSMutableOrderedSet()
         let awaitedKey: Byte = 5
-        downKeys.add(awaitedKey)
         let initialIsAwaiting = true
 
         var state = ChipState()
         state.v = v
-        state.downKeys = downKeys
+        state.downKeys = [awaitedKey]
         state.isAwaitingKey = initialIsAwaiting
 
         let newState = try! opExecutor.handle(state: state, op: op)
@@ -1280,13 +1274,11 @@ class OpExecutorTests: XCTestCase {
     func test_WAITKEY_0x0f_increments_pc_when_awaited_key_pressed() {
         let x: Byte = 0x02
         let op = Word(nibbles: [0x0f, x, 0x00, 0x0a])
-        let downKeys = NSMutableOrderedSet()
         let awaitedKey: Byte = 5
-        downKeys.add(awaitedKey)
         let initialPc: Word = 0x88a
 
         var state = ChipState()
-        state.downKeys = downKeys
+        state.downKeys = [awaitedKey]
         state.pc = initialPc
         state.isAwaitingKey = true
 


### PR DESCRIPTION
## Summary
- Replace `NSMutableOrderedSet` with `[Byte]` array for WASM compatibility (maintains insertion order, no duplicates)
- Add `#if canImport(...)` guards around platform-specific code (`AVFoundation`, `CoreGraphics`, `ObjectiveC`, `AppKit`/`UIKit`) so the package compiles on non-Apple platforms
- Add public `tick()` method to `Chip8Engine` for external game loop driving (e.g. from `requestAnimationFrame` in a web target)
- Make `RomLoader.loadRam(from: [Byte])` public for direct byte-array ROM loading

## Compatibility
- All 89 existing tests pass with 0 failures
- Native macOS build verified — no behavioral changes on Apple platforms
- Downstream projects (watchOS, tvOS, iOS/AR, macOS) are unaffected: conditional compilation preserves all existing code paths

## Test plan
- [x] Run `swift test` — 89/89 pass
- [x] Run `swift build` for macOS — succeeds
- [ ] Build downstream watchOS/tvOS/iOS/macOS apps against this branch to verify no regressions
- [ ] Build for WASM target (requires SwiftWasm SDK) to verify the conditional compilation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)