### PR TITLE
Add missing consumer projects to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ extension YourViewController: Chip8EngineDelegate {
 - [chip-8-macOS](https://github.com/ryanggrey/chip-8-macos)
 - [chip-8-watchOS](https://github.com/ryanggrey/chip-8-watchOS)
 - [chip-8-tvOS](https://github.com/ryanggrey/chip-8-tvOS)
+- [CHIP8AR](https://github.com/ryanggrey/CHIP8AR) (iOS, AR)
+- [chip-8-web](https://github.com/ryanggrey/chip-8-web) (Web, SwiftWasm)
 
 ## Assets
 ### ROMs


### PR DESCRIPTION
## Summary
- Add CHIP8AR (iOS, AR) and chip-8-web (Web, SwiftWasm) to the consumer projects list

🤖 Generated with [Claude Code](https://claude.com/claude-code)